### PR TITLE
gPLink issue - Update LDAP filter

### DIFF
--- a/LibSnaffle/ActiveDirectory/ActiveDirectory.cs
+++ b/LibSnaffle/ActiveDirectory/ActiveDirectory.cs
@@ -308,7 +308,7 @@ namespace LibSnaffle.ActiveDirectory
                 {
                     using (DirectorySearcher mySearcher = new DirectorySearcher(confEntry))
                     {
-                        mySearcher.Filter = "(objectClass=site)";
+                        mySearcher.Filter = "(&(objectClass=site)(gPLink=*))";
                         mySearcher.PropertiesToLoad.Add("gPLink");
 
                         // No size limit, reads all objects
@@ -340,7 +340,7 @@ namespace LibSnaffle.ActiveDirectory
                 {
                     using (DirectorySearcher mySearcher = new DirectorySearcher(entry))
                     {
-                        mySearcher.Filter = "(objectClass=organizationalUnit)";
+                        mySearcher.Filter = "(&(objectCategory=organizationalUnit)(gPLink=*))";
                         mySearcher.PropertiesToLoad.Add("gplink");
 
                         // No size limit, reads all objects


### PR DESCRIPTION
An error occurs when searching for the gplink attribute in a site or an organizationalUnit object:

```
2021-10-01 17:54:51 +02:00 [Trace] This is where the horrible GPO link bug happens...
2021-10-01 17:54:51 +02:00 [Trace] adspath went ok... - LDAP://test.loc/CN=XXX1,CN=Sites,CN=Configuration,DC=test,DC=loc
2021-10-01 17:54:51 +02:00 [Trace] gplink went ok too...  
2021-10-01 17:54:51 +02:00 [Trace] This is where the horrible GPO link bug happens...
2021-10-01 17:54:51 +02:00 [Trace] adspath went ok... - LDAP://test.loc/CN=XXX2,CN=Sites,CN=Configuration,DC=test,DC=loc
2021-10-01 17:54:51 +02:00 [Error] Something went wrong inserting GPO links into the GPO objects.System.ArgumentOutOfRangeException: L'index était hors limites. Il ne doit pas être négatif et doit être inférieur à la taille de la collection.
Nom du paramètre: index
   … System.Collections.ArrayList.get_Item(Int32 index)
   … System.DirectoryServices.ResultPropertyValueCollection.get_Item(Int32 index)
   … LibSnaffle.ActiveDirectory.ActiveDirectory.EnumerateDomainGpoLinks() dans C:\Group3r-main\LibSnaffle\ActiveDirectory\ActiveDirectory.cs:ligne 377
```

From my understanding, if no GPO has ever been linked on an object, the gplink attribute is not "initialized".
I propose to modify the LDAP filter in the previous queries to ensure that the object has the gplink attribute.