### PR TITLE
Prefer SID resolution to name matching

### DIFF
--- a/Group3r/Assessment/Analysers/Group.cs
+++ b/Group3r/Assessment/Analysers/Group.cs
@@ -32,6 +32,10 @@ namespace Group3r.Assessment.Analysers
                 {
                     group = assessmentOptions.TrusteeOptions.Where(trusteeOption => trusteeOption.SID.Equals(setting.Name, StringComparison.OrdinalIgnoreCase)).First();
                 }
+                else if (setting.GroupSid.StartsWith("S-"))
+                {
+                    group = assessmentOptions.TrusteeOptions.Where(trusteeOption => trusteeOption.SID.Equals(setting.GroupSid, StringComparison.OrdinalIgnoreCase)).First();
+                }
                 else
                 {
                     group = assessmentOptions.TrusteeOptions.Where(trusteeOption => trusteeOption.DisplayName.Equals(setting.Name, StringComparison.OrdinalIgnoreCase)).First();

--- a/LibSnaffle/ActiveDirectory/GPO/GpoSettings/GroupSetting.cs
+++ b/LibSnaffle/ActiveDirectory/GPO/GpoSettings/GroupSetting.cs
@@ -7,6 +7,7 @@ namespace LibSnaffle.ActiveDirectory
         public string Name { get; set; } = "";
         public string NewName { get; set; } = "";
         public string Description { get; set; }
+        public string GroupSid { get; set; }
         public bool DeleteAllGroups { get; set; }
         public bool DeleteAllUsers { get; set; }
         public bool RemoveAccounts { get; set; }

--- a/LibSnaffle/ActiveDirectory/Sysvol/GpoFiles/XmlGpoFile.cs
+++ b/LibSnaffle/ActiveDirectory/Sysvol/GpoFiles/XmlGpoFile.cs
@@ -64,6 +64,7 @@ namespace LibSnaffle.ActiveDirectory
                                 groupSetting.RemoveAccounts = thing3;
                             }
                             groupSetting.Description = groupPropertiesAttributes?["description"]?.Value;
+                            groupSetting.GroupSid = groupPropertiesAttributes?["groupSid"]?.Value;
                             XmlNodeList groupMembers = groupProperties?["Members"]?.ChildNodes;
                             if (groupMembers != null)
                             {


### PR DESCRIPTION
While analyzing the groups.xml files I got the following error:

```
2022-03-16 12:54:54 +01:00 [Trace] Analysing *****
2022-03-16 12:54:54 +01:00 [Trace] Group Utilisateurs du module COM distribué threw an error trying to match it to a well known name or well known sid.System.InvalidOperationException: La squence ne contient aucun lment.
    System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
    Group3r.Assessment.Analysers.GroupAnalyser.Analyse(AssessmentOptions assessmentOptions) dans C:\xxxx\Group3r\Group3r\Assessment\Analysers\Group.cs:ligne 37
```

Well, the GPO was created in French and therefore the group name (in French) is not automatically resolved in the analysis. For example, the associated group in your Trustees is "BUILTIN\\Distributed COM Users" (S-1-5-32-562) and is tagged as interesting. 

I found that the group.xml file could contain a "groupsid" parameter in addition to the group name, but I'm not sure if it is always present... 

So I propose to add this information in the dump and use it in the analysis before comparing the group name.

Let me know if you have another idea to handle this :)
