### PR TITLE
Fix registry value being overwritten for multivalued settings

### DIFF
--- a/LibSnaffle/ActiveDirectory/Sysvol/GpoFiles/InfGpoFile.cs
+++ b/LibSnaffle/ActiveDirectory/Sysvol/GpoFiles/InfGpoFile.cs
@@ -162,10 +162,6 @@ namespace LibSnaffle.ActiveDirectory
                                 // get the key
                                 string[] keyArray = regPathArray.Skip(1).Take(regPathArray.Length - 2).ToArray();
                                 regValSetting.Key = String.Join("\\", keyArray);
-                                RegistryValue regVal = new RegistryValue
-                                {
-                                    ValueName = regPathArray[regPathArray.Length - 1]
-                                };
 
                                 // figure out the value type
                                 int valType;
@@ -174,6 +170,10 @@ namespace LibSnaffle.ActiveDirectory
                                     // create value objects for each of them
                                     foreach (string value in splitValues.Skip(1))
                                     {
+                                        RegistryValue regVal = new RegistryValue
+                                        {
+                                            ValueName = regPathArray[regPathArray.Length - 1]
+                                        };
                                         regVal.RegKeyValType = (RegKeyValType)valType;
                                         regVal.ValueBytes = Encoding.Unicode.GetBytes(value);
                                         regVal.ValueString = value;


### PR DESCRIPTION
Currently the regVal object is defined outside of the loop, so for multivalued attributes (`REG_MULTI_SZ`) it will keep updating the value on the same object, which means all the values will be duplicates of the last one.

Fixing this by creating a new object for each value.