### PR TITLE
changed clock skew default (setting is in seconds, not minutes)

### DIFF
--- a/Group3r/Assessment/Analysers/KerbPolicy.cs
+++ b/Group3r/Assessment/Analysers/KerbPolicy.cs
@@ -58,7 +58,7 @@ namespace Group3r.Assessment.Analysers
 
             else if (setting.Key == "MaxClockSkew")
             {
-                if (setting.Value != "600")
+                if (setting.Value != "5")
                 {
                     findings.Add(new GpoFinding()
                     {


### PR DESCRIPTION
default should be 5, not 600 
https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/maximum-tolerance-for-computer-clock-synchronization